### PR TITLE
[DOC] Changed --rebase parameter order

### DIFF
--- a/6.DeveloperResources/6.2.Contributing.md
+++ b/6.DeveloperResources/6.2.Contributing.md
@@ -77,7 +77,7 @@ To keep your local `development` branch up-to-date:
 
 ```bash
 git checkout development
-git pull upstream development --rebase
+git pull --rebase upstream development
 ```
 
 You can perform this operation as many times as you want, but make sure any changes you have made have been properly committed first.


### PR DESCRIPTION
git pull upstream development --rebase is not working at least with ZSH. Changed to git pull --rebase upstream development that is working also in ZSH
