### PR TITLE
[TASK] Change TS example to use xxxRootPaths (plural)

### DIFF
--- a/3.Templating/3.1.ProviderExtension/3.1.5.ConfigurationFiles.md
+++ b/3.Templating/3.1.ProviderExtension/3.1.5.ConfigurationFiles.md
@@ -37,9 +37,9 @@ Always includes the configuration, in order of extension loading.
 // ext_localconf.php
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScript($_EXTKEY, 'setup', '
 	plugin.tx_myextensionkey.view {
-		templateRootPath = EXT:flux/Resources/Private/Templates/
-		partialRootPath = EXT:flux/Resources/Private/Partials/
-		layoutRootPath = EXT:flux/Resources/Private/Layouts/
+		templateRootPaths.10 = EXT:flux/Resources/Private/Templates/
+		partialRootPaths.10 = EXT:flux/Resources/Private/Partials/
+		layoutRootPaths.10 = EXT:flux/Resources/Private/Layouts/
 	}
 ');
 


### PR DESCRIPTION
Array key `.10` is used to harmonize with `FluxService->getDefaultViewConfigurationForExtensionKey()` and to add the ability to clear/overwrite these settings via TS (see https://github.com/FluidTYPO3/flux/issues/839#issuecomment-105763399).
