### PR TITLE
[DOC] Fix link to contribution guide

### DIFF
--- a/5.Appendix/5.2.GitWorkflow.md
+++ b/5.Appendix/5.2.GitWorkflow.md
@@ -101,11 +101,11 @@ git pull --rebase upstream master
 
 We recommend to do this everytime you are about to start a new feature branch.
 
-The full guide is available at http://fedext.net/overview/contributing/contribution-guide.html
+The full guide is available at https://fluidtypo3.org/documentation/contributing/contribution-guide.html
 
 Last words: welcome to the growing list of contributors! :)
 
-[contributionGuide]: http://fedext.net/overview/contributing/contribution-guide.html "FluidTYPO3 contribution guide"
+[contributionGuide]: https://fluidtypo3.org/documentation/contributing/contribution-guide.html "FluidTYPO3 contribution guide"
 [pomodoro]: http://www.pomodorotechnique.com/ "The Pomodory Technique"
 
 ## Using Travis-CI


### PR DESCRIPTION
Replaces dead link http://fedext.net/overview/contributing/contribution-guide.html with https://fluidtypo3.org/documentation/contributing/contribution-guide.html
