### PR TITLE
[DOC] Edited 3.1.4.RegistrationInPHP.md

### DIFF
--- a/3.Templating/3.1.ProviderExtension/3.1.4.RegistrationInPHP.md
+++ b/3.Templating/3.1.ProviderExtension/3.1.4.RegistrationInPHP.md
@@ -9,7 +9,7 @@ In order to tell Flux that you have added a Provider Extension and that your Pro
 \FluidTYPO3\Flux\Core::registerProviderExtensionKey('myextensionkey', 'Page');
 ```
 
-> TYPO3 versions before 6.2 require that you also add these exact same lines in `ext_tables.php`. This is due to the way TYPO3 caches and loads cached versions of the `tables` and `localconf` file types. On TYPO3 6.2 and above, you only need to add this in `ext_localconf.php` or `ext_tables.php` - which one you choose doesn't matter, but for consistency we recommend always using `ext_localconf.php`.
+> TYPO3 versions before 6.2 require that you also add these exact same lines in `ext_tables.php`. This is due to the way TYPO3 caches and loads cached versions of the `tables` and `localconf` file types. On TYPO3 6.2 and v7, you only need to add this in `ext_localconf.php` or `ext_tables.php` - which one you choose doesn't matter, but for consistency we recommend always using `ext_localconf.php`. On TYPO3 v8 and above only `ext_localconf.php` is used by the frontend. 
 
 This instructs Flux that a) a new Provider Extension now exists and b) it contains templates for the `Content` controller type and c) it also contains templates for the `Page` controller type. It is important to notice that Flux itself does not render these templates (Flux does, however, read the configuration stored within them!) - Flux's role in this case is simply to provide a shared API which can keep track of which Provider Extension contains which template types.
 


### PR DESCRIPTION
Clarified roles of ext_tables.php and ext_localconf.php in new versions of TYPO3.